### PR TITLE
Base changes on latest `h3-go` version

### DIFF
--- a/example_test.go
+++ b/example_test.go
@@ -3,7 +3,7 @@ package h3_test
 import (
 	"fmt"
 
-	"github.com/uber/h3-go/v4"
+	"github.com/starboard-nz/h3-go/v4"
 )
 
 func ExampleLatLngToCell() {

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/uber/h3-go/v4
+module github.com/starboard-nz/h3-go/v4
 
 go 1.21

--- a/h3_algos.c
+++ b/h3_algos.c
@@ -800,6 +800,9 @@ H3Error H3_EXPORT(maxPolygonToCellsSize)(const GeoPolygon *geoPolygon, int res,
     // function provides (but beefing that up to cover causes most situations to
     // overallocate memory)
     numHexagons += POLYGON_TO_CELLS_BUFFER;
+
+    // Double the allocation for starboard's specific use cases of VERY large polygons
+    numHexagons *= 2.1;
     *out = numHexagons;
     return E_SUCCESS;
 }

--- a/h3_test.go
+++ b/h3_test.go
@@ -82,6 +82,14 @@ var (
 		{Lat: 67.234563187, Lng: -168.286102782},
 	}
 
+	// large area geoloop
+	largeGeoLoop = GeoLoop{
+		{Lat: 50, Lng: 0},
+		{Lat: 50, Lng: 180},
+		{Lat: 90, Lng: 180},
+		{Lat: 90, Lng: 0},
+	}
+
 	validHole1 = GeoLoop{
 		{Lat: 67.2, Lng: -168.4},
 		{Lat: 67.1, Lng: -168.4},
@@ -576,6 +584,13 @@ func TestPolygonToCells(t *testing.T) {
 		assertErr(t, err)
 		assertErrIs(t, err, ErrResolutionDomain)
 		assertNil(t, cells)
+	})
+
+	t.Run("large area", func(t *testing.T) {
+		t.Parallel()
+
+		_, err := GeoPolygon{GeoLoop: largeGeoLoop}.Cells(6)
+		assertNoErr(t, err)
 	})
 }
 


### PR DESCRIPTION
`h3-go` has been upgraded to `4.2.2` and they are returning error codes from `PolygonToCells` - which is the initial reason why I make this fork in the first place. I've re-implemented my increased memory allocation so that it works for Starboard's large area use cases. 